### PR TITLE
fixed spec generator to use Rspec.describe and include rails_helper

### DIFF
--- a/lib/generators/rspec/templates/cell_spec.erb
+++ b/lib/generators/rspec/templates/cell_spec.erb
@@ -1,6 +1,6 @@
-require 'spec_helper'
+require 'rails_helper'
 
-describe <%= class_name %>Cell, type: :cell do
+Rspec.describe <%= class_name %>Cell, type: :cell do
 
   context 'cell rendering' do
   <%- actions.each_with_index do |state, index| -%>

--- a/spec/cells/cell_generator_spec.rb
+++ b/spec/cells/cell_generator_spec.rb
@@ -31,8 +31,8 @@ describe Rspec::Generators::CellGenerator do
     end
 
     it "creates widget spec" do
-      test.assert_file "spec/cells/twitter_cell_spec.rb", t("require 'spec_helper'")
-      test.assert_file "spec/cells/twitter_cell_spec.rb", t('describe TwitterCell, type: :cell do')
+      test.assert_file "spec/cells/twitter_cell_spec.rb", t("require 'rails_helper'")
+      test.assert_file "spec/cells/twitter_cell_spec.rb", t('Rspec.describe TwitterCell, type: :cell do')
       test.assert_file "spec/cells/twitter_cell_spec.rb", t('context \'cell rendering\' do')
       test.assert_file "spec/cells/twitter_cell_spec.rb", t('end')
     end
@@ -64,8 +64,8 @@ describe Rspec::Generators::CellGenerator do
     end
 
     it "creates widget spec" do
-      test.assert_file "spec/cells/twitter_cell_spec.rb", t("require 'spec_helper'")
-      test.assert_file "spec/cells/twitter_cell_spec.rb", t('describe TwitterCell, type: :cell do')
+      test.assert_file "spec/cells/twitter_cell_spec.rb", t("require 'rails_helper'")
+      test.assert_file "spec/cells/twitter_cell_spec.rb", t('Rspec.describe TwitterCell, type: :cell do')
       test.assert_file 'spec/cells/twitter_cell_spec.rb', t('context \'cell rendering\' do')
       test.assert_file "spec/cells/twitter_cell_spec.rb", t('end')
     end
@@ -100,7 +100,7 @@ describe Rspec::Generators::CellGenerator do
     GENERATED_FILE = "spec/cells/forum/comment_cell_spec.rb"
 
     it "creates widget spec" do
-      test.assert_file GENERATED_FILE, t("require 'spec_helper'")
+      test.assert_file GENERATED_FILE, t("require 'rails_helper'")
       test.assert_file GENERATED_FILE, t('describe Forum::CommentCell, type: :cell do')
       test.assert_file GENERATED_FILE, t('context \'cell rendering\' do')
       test.assert_file GENERATED_FILE, t('end')


### PR DESCRIPTION
Currently, spec generator uses a template that can't load the Cell because rails_helper is not called (hence the Rails env is not loaded, including the cells). 
Also prefixing the describe method with Rspec

It's an PR extension to #62