### PR TITLE
* Only require the "index file" of `rspec-rails`

### DIFF
--- a/lib/rspec/cells.rb
+++ b/lib/rspec/cells.rb
@@ -1,7 +1,7 @@
 require 'cell/test_case'
+
 require 'rspec/core'
-require 'rspec/rails/adapters'
-require 'rspec/rails/fixture_support'
-require 'rspec/rails/example/rails_example_group'
+# We only require the "index file" of `rspec-rails` to avoid file structure change
+require 'rspec/rails'
 require 'rspec/cells/cell_example_group'
 require 'rspec/cells/caching'


### PR DESCRIPTION
To avoid file structure change