### PR TITLE
Revert "* Only require the "index file" of `rspec-rails`"

### DIFF
--- a/lib/rspec/cells.rb
+++ b/lib/rspec/cells.rb
@@ -1,7 +1,8 @@
 require 'cell/testing'
 
 require 'rspec/core'
-# We only require the "index file" of `rspec-rails` to avoid file structure change
-require 'rspec/rails'
+require 'rspec/rails/adapters'
+require 'rspec/rails/fixture_support'
+require 'rspec/rails/example/rails_example_group'
 require 'rspec/cells/example_group'
 require 'rspec/cells/caching'


### PR DESCRIPTION
apotonick/rspec-cells#74 has broke the usage of `rspec-cells`, I can't run my test with 3fe294f866271d99f1b4748adbdf5710a3643026 commit and all commits behind.